### PR TITLE
fix window.SetMaximized

### DIFF
--- a/rayed.bqn
+++ b/rayed.bqn
@@ -351,7 +351,7 @@ window ← {
   SetHidden            ⇐ {B𝕩 ⋄ hidden            ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_hidden            } # window.SetHidden
   SetRunWhileMinimized ⇐ {B𝕩 ⋄ runWhileMinimized ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_always_run        } # window.SetRunWhileMinimized
   SetMinimized         ⇐ {B𝕩 ⋄ minimized         ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_minimized         } # window.SetMinimized
-  SetMaximized         ⇐ {B𝕩 ⋄ maximized         ↩ 𝕩 ⊣   raylib.MaximizeWindow∘⟨⟩⍟(𝕩=IWS)⍟isOpen cf.window_maximized} # window.SetMaximized
+  SetMaximized         ⇐ {B𝕩 ⋄ maximized         ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_maximized         } # window.SetMaximized
   SetFocused           ⇐ {B𝕩 ⋄ focused           ↩ 𝕩 ⊣ ¬∘𝕩◶cs⍟isOpen cf.window_unfocused         } # window.SetFocused
   SetTopmost           ⇐ {B𝕩 ⋄ topmost           ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_topmost           } # window.SetTopmost
   SetHighDPI           ⇐ {B𝕩 ⋄ highDPI           ↩ 𝕩 ⊣   𝕩◶cs⍟isOpen cf.window_highDPI           } # window.SetHighDPI


### PR DESCRIPTION
Currently, `window.SetMaximized` does the opposite of what it's described to, due to attempting to maximize if it's already maximized. This change fixes that via changing `𝕩=IWS` to `𝕩≠IWS`.

Additionally, this also makes `window.SetMaximized 0` functional via calling `RestoreWindow` for it; could do a similar thing for `SetMinimized 0` but it doesn't seem to actually do anything (at least on Linux; testing under `window.SetRunWhileMinimized 1` of course).

(maybe there should be a check for is-not-minimized for `SetMaximized 0` to attempt `RestoreWindow`? either behavior would be weird though, and `RestoreWindow` doesn't seem to do anything while minimized anyway)