### PR TITLE
Make draw.circle also use DrawCircleV, in line with commit 7403739 (fix #49)

### DIFF
--- a/rayed.bqn
+++ b/rayed.bqn
@@ -530,9 +530,8 @@ draw ← {
   Circle ← {r‿g‿b‿a𝕊⟨x‿y⋄radius⟩: # color 𝕊 pos‿radius
     NeedsWindow@
     (𝕨‿𝕩•Type⊸⊑⟜"_icfmdn"⚇0⊸≡"iiii"‿⟨"ii"⋄'i'⟩)!˜"Wrong input types given to draw.Circle"
-    ((∧´⌈⊸=∨∞=|)x‿y)!˜"Position for draw.Circle has to be two ints"
     ((∧´0⊸≤∧≤⟜255)𝕨)!˜"𝕨 (color) only accepts ints in the range 0-255 inclusive"
-    raylib.DrawCircle x‿y‿radius‿𝕨
+    raylib.DrawCircleV ⟨x‿y,radius,𝕨⟩
   }
 
   # draw.EllipseOutline


### PR DESCRIPTION
Fixes one function missing from previous fix to #49.

Unlike [7403739](https://github.com/Brian-ED/rayed-bqn/commit/7403739858df3509bc15c414c5803f1a58a9aceb), I didn't add a test for this shape as I wasn't sure how to fit it into the program.