### PR TITLE
Make raylib search paths configurable.

### DIFF
--- a/src/defaultSearchPaths.bqn
+++ b/src/defaultSearchPaths.bqn
@@ -1,0 +1,11 @@
+# Default paths to search for the raylib shared library.
+# Imported by searchPaths.bqn unless replaced by a packager.
+{
+  # C:\raylib is default installation location for the raylib-provided-installer
+  "windows": "lib"‿"C:\raylib\raylib\lib"
+  ;"linux" : "lib"‿"/usr/local/lib"
+  ;"darwin":
+    e‿stdout‿·←•SH⎊1‿⟨⟩‿@ "brew"‿"--prefix"‿"raylib"
+    brewPath ← ⟨(@+10)⊸≠⊸/stdout⟩⍟(0≢e)⟨⟩
+    "lib"‿"/usr/local/lib"∾brewPath
+}•platform.os

--- a/src/loadRaylib.bqn
+++ b/src/loadRaylib.bqn
@@ -23,14 +23,7 @@ raylibLibPath ← {
       "Try providing binary as argument (⟨•file.RealPath ""raylib.so""⟩•Import""rayed.bqn"")"
     ⟩
   }•platform.os
-  validPaths ← Exists¨⊸/ At⟜raylibName¨ {
-    "windows": "lib"‿"C:\raylib\raylib\lib"  # C:\raylib is default installation location for the raylib-provided-installer
-    ;"linux" : "lib"‿"/usr/local/lib"
-    ;"darwin":
-      e‿stdout‿·←•SH⎊1‿⟨⟩‿@ "brew"‿"--prefix"‿"raylib"
-      brewPath ← ⟨(@+10)⊸≠⊸/stdout⟩⍟(0≢e)⟨⟩
-      "lib"‿"/usr/local/lib"∾brewPath
-  }•platform.os
+  validPaths ← Exists¨⊸/ At⟜raylibName¨ •Import "searchPaths.bqn"
   {𝕊:
     !∾lf∾¨⟨
       "Path to raylib binary not found at install location."
@@ -40,6 +33,9 @@ raylibLibPath ← {
       ""
       "  Already installed raylib? Tell rayed.bqn where to find it"
       "    ⟨•file.RealPath ""path/to/"∾raylibName∾"""⟩•Import""rayed.bqn"")"
+      ""
+      "  Packaging rayed.bqn? Set the search path in"
+      "    "∾•file.RealPath "searchPaths.bqn"
       ""
     ⟩
   }⍟(0=≠)validPaths

--- a/src/searchPaths.bqn
+++ b/src/searchPaths.bqn
@@ -1,0 +1,5 @@
+# Packagers may replace this file with specific paths, e.g.
+# ⟨"/usr/lib/x86_64-linux-gnu"⟩
+# To keep the defaults, prepend to them:
+# ⟨"/usr/lib/x86_64-linux-gnu"⟩ ∾ •Import "searchPaths.bqn"
+•Import "defaultSearchPaths.bqn"


### PR DESCRIPTION
Default platform specific paths go to src/defaultSearchPaths.bqn. src/searchPaths.bqn loads these paths by default, and may also be rewritten with a list of paths.
This is to enable a packager (e.g. guix) to overwrite the search paths (instead of regex replacing default linux paths) so callers don't need to know the exact path in /gnu/store.

we can discuss this further. The idea is when packaging for guix, we replace src/searchPaths.bqn with the exact path of libraylib.so in /gnu/store. I split into two files so we keep the upstream maintainer logic (defaultSearchPaths) and a shim that loads it (searchPaths).